### PR TITLE
Fix /press window is not defined.

### DIFF
--- a/src/containers/Press/index.tsx
+++ b/src/containers/Press/index.tsx
@@ -6,11 +6,9 @@ import SingleLink, { DisplayDirection } from '@components/Press/SingleLink';
 import colors from '@styles/json/colors';
 
 class Press extends Component {
-  state: {
-    displayDirection: DisplayDirection;
-  };
+  state: { displayDirection?: DisplayDirection } = {};
 
-  componentWillMount() {
+  componentDidMount() {
     const displayDirection = window.innerWidth > 768 ? 'row' : 'column';
     this.setState({ displayDirection });
 
@@ -25,7 +23,7 @@ class Press extends Component {
   }
 
   render() {
-    const { displayDirection } = this.state;
+    const { displayDirection = 'row' } = this.state;
 
     return (
       <div>


### PR DESCRIPTION
##### Description
Why: Since we use react server render, Container's componentWillMount method runs in the server side that can't the window variable

How to fix: use componentDidMount instead.

##### Checklist

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
No

##### Testing


##### Refers/Fixes
window is not defined
