### PR TITLE
Add CTA to engineering weekly call section

### DIFF
--- a/src/components/About/Opensource.tsx
+++ b/src/components/About/Opensource.tsx
@@ -169,6 +169,15 @@ class Opensource extends React.Component {
               <p style={{ fontSize: '24px', fontWeight: '500' }}>
                 Every Thurdsay 8AM MT
               </p>
+              <ButtonWrapper type="primary">
+                <Link
+                  to="https://github.com/MARKETProtocol/community/blob/master/docs/engineering-weekly.md"
+                  target="_blank"
+                  style={{ color: 'inherit', textDecoration: 'none' }}
+                >
+                  Learn more
+                </Link>
+              </ButtonWrapper>
             </TextWrapper>
           </Col>
         </Row>


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/MARKETProtocol/meta/blob/master/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->

Adds a 'Learn More' button to Engineering weekly call section on the about page.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like Docs, UI, UX, Tests etc). -->
UI

##### Screenshots (Optional) 
<!-- Please attach screenshots of all purposeful UI changes (before and after screens are recommended). -->

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->

Fixes #118 
