### PR TITLE
Use Link component instead of anchor component to avoid page reload

### DIFF
--- a/src/components/NewsletterSubscribeBanner.tsx
+++ b/src/components/NewsletterSubscribeBanner.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-static';
 import { Button, Form, Icon, Input } from 'antd';
 import styled from 'styled-components';
 import { device, size } from '@src/breakpoints';
@@ -173,23 +174,24 @@ export class NewsletterSubscribeBannerComponent extends React.Component<
         <StyledCol lg={12}>
           <LearnAboutTeamWrapper>
             <SectionTitle>Learn about our team</SectionTitle>
-            <Button
-              size={'large'}
-              href={'/team'}
-              style={{
-                alignItems: 'center',
-                backgroundColor: '#00E2C1',
-                color: '#000',
-                display: 'flex',
-                fontSize: 12,
-                fontWeight: 300,
-                justifyContent: 'space-between',
-                width: '100%'
-              }}
-            >
-              <b>The minds behind MARKET Protocol</b>
-              <Icon type="arrow-right" style={{ fontSize: 18 }} />
-            </Button>
+            <Link to="/team">
+              <Button
+                size={'large'}
+                style={{
+                  alignItems: 'center',
+                  backgroundColor: '#00E2C1',
+                  color: '#000',
+                  display: 'flex',
+                  fontSize: 12,
+                  fontWeight: 300,
+                  justifyContent: 'space-between',
+                  width: '100%'
+                }}
+              >
+                <b>The minds behind MARKET Protocol</b>
+                <Icon type="arrow-right" style={{ fontSize: 18 }} />
+              </Button>
+            </Link>
           </LearnAboutTeamWrapper>
         </StyledCol>
       </NewsletterSubscribeBannerWrapper>

--- a/test/components/NewsletterSubscribeBanner.test.tsx
+++ b/test/components/NewsletterSubscribeBanner.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { MemoryRouter } from 'react-router';
 import { mount } from 'enzyme';
 import { Form, Input } from 'antd';
 
@@ -10,9 +11,15 @@ import NewsletterSubscribeBanner, {
 
 
 describe('<NewsletterSubscribeBanner />', () => {
+  let component: typeof NewsletterSubscribeBanner;
+
+  beforeEach(() => {
+    component = mount(
+      <MemoryRouter><NewsletterSubscribeBanner/></MemoryRouter>
+    );
+  });
 
   it('renders without crashing', () => {
-    const component = mount(<NewsletterSubscribeBanner />);
     expect(component.find('NewsletterSubscribeBannerComponent').length).toEqual(
       1
     );
@@ -20,12 +27,10 @@ describe('<NewsletterSubscribeBanner />', () => {
 
   describe('layout', () => {
     it('renders 2 StyledCol', () => {
-      const component = mount(<NewsletterSubscribeBanner />);
       expect(component.find(StyledCol).length).toBe(2);
     });
 
-    it("renders 2 SectionTitle's with the correct text", () => {
-      const component = mount(<NewsletterSubscribeBanner />);
+    it('renders 2 SectionTitle\'s with the correct text', () => {
       expect(component.find(SectionTitle).length).toBe(2);
       expect(
         component
@@ -44,7 +49,6 @@ describe('<NewsletterSubscribeBanner />', () => {
 
   describe('Newsletter signup form', () => {
     it('renders a Form with the correct action url', () => {
-      const component = mount(<NewsletterSubscribeBanner />);
       expect(component.find(Form).length).toBe(1);
       expect(
         component
@@ -55,7 +59,6 @@ describe('<NewsletterSubscribeBanner />', () => {
     });
 
     it('renders a text Input', () => {
-      const component = mount(<NewsletterSubscribeBanner />);
       expect(component.find(Form).find(Input).length).toBe(1);
       expect(
         component
@@ -67,7 +70,6 @@ describe('<NewsletterSubscribeBanner />', () => {
     });
 
     it('indicates an email error', () => {
-      const component = mount(<NewsletterSubscribeBanner />);
       component.find('form').simulate('submit');
       expect(
         component
@@ -78,14 +80,15 @@ describe('<NewsletterSubscribeBanner />', () => {
     });
   });
 
-  describe('Become a Partner email link', () => {
-    const component = mount(<NewsletterSubscribeBanner />);
-    expect(component.find(LearnAboutTeamWrapper).find('a').length).toBe(1);
-    expect(
-      component
-        .find(LearnAboutTeamWrapper)
-        .find('a')
-        .props().href
-    ).toEqual('/team');
+  describe('Learn more about team', () => {
+    it('renders a link to team page', () => {
+      expect(component.find(LearnAboutTeamWrapper).find('a').length).toBe(1);
+      expect(
+        component
+          .find(LearnAboutTeamWrapper)
+          .find('a')
+          .props().href
+      ).toEqual('/team');
+    });
   });
 });

--- a/test/containers/Partners/Partners.test.tsx
+++ b/test/containers/Partners/Partners.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { MemoryRouter } from 'react-router';
 import { mount } from 'enzyme';
 import Partners from '@containers/Partners';
 import config from '@containers/Partners/config';
@@ -6,22 +7,27 @@ import NewsletterSubscribeBanner from '@components/NewsletterSubscribeBanner';
 import Hero from "@src/components/Partners/Hero";
 
 describe(`/partners Page`, () => {
+  let component: typeof Partners;
+
+  beforeEach(() => {
+    component = mount(
+      <MemoryRouter><Partners /></MemoryRouter>
+    );
+  });
+
   it('should render a <Partners /> component without crashing', () => {
-    const component = mount(<Partners />);
     expect(component.find(Partners).length).toEqual(1);
     expect(component.find(Hero).length).toEqual(1);
   });
 
   describe('body area', () => {
     it('should render all the partners defined in the config', () => {
-      const component = mount(<Partners />);
       expect(component.find('.partner-link').length).toEqual(
         config.partnerProjects.length
       );
     });
 
     it('should render a "Join our mission" section with wtih a CTA', () => {
-      const component = mount(<Partners />);
       expect(component.find('.join-cta-banner').length).toEqual(1);
       expect(
         component
@@ -32,7 +38,6 @@ describe(`/partners Page`, () => {
     });
 
     it('should render a NewsletterSubscribeBanner', () => {
-      const component = mount(<Partners />);
       expect(component.find(NewsletterSubscribeBanner).length).toEqual(1);
     });
   });


### PR DESCRIPTION
##### Description
<!-- A description on what this PR aims to solve -->

Use `Link` component around 'The Minds behind the MARKET Protocol' team button to avoid page reload.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like Docs, UI, UX, Tests etc). -->
UX

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->
Fixes #122 