### PR TITLE
Make sure blog post header image is responsive

### DIFF
--- a/src/containers/BlogPost/BlogPost.tsx
+++ b/src/containers/BlogPost/BlogPost.tsx
@@ -117,6 +117,8 @@ const Croppit = styled.div`
   width: 100%
   height: 300px;
   overflow: hidden;
+  background-size: cover;
+  background-position: center;
 `;
 const BlogImage = styled.img`
   width: 100%;
@@ -276,9 +278,11 @@ class BlogPost extends React.Component<BlogPostProps, {}> {
                 />
               </Link>
               <BlogContainer>
-                <Croppit>
-                  <BlogImage src={post.data.thumbnail} alt={''} />
-                </Croppit>
+                <Croppit
+                  style={{
+                    backgroundImage: `url(${post.data.thumbnail})`
+                  }}
+                />
                 <ContentContainer>
                   <RowContainer>
                     <CategoryContainer className="category">

--- a/test/containers/BlogPost/BlogPost.test.tsx
+++ b/test/containers/BlogPost/BlogPost.test.tsx
@@ -67,11 +67,22 @@ describe('<BlogPost />', () => {
   })
 
   it('renders BlogImage thumbnail component', () => {
-    expect(component.find({ src: samplePost.data.thumbnail }).length).toEqual(1);
+    const croppitElement = component.findWhere(node => {
+      const styles = node.prop('style');
+      return styles && styles.backgroundImage;
+    });
+
+    expect(croppitElement.length).toEqual(1);
   });
 
   it('renders correct src for BlogImage thumbnail component', () => {
-    expect(component.find({ src: samplePost.data.thumbnail }).prop('src')).toEqual(samplePost.data.thumbnail);
+    const croppitElement = component.findWhere(node => {
+      const styles = node.prop('style');
+      return styles && styles.backgroundImage;
+    });
+
+    const { backgroundImage } = croppitElement.prop('style');
+    expect(backgroundImage).toEqual(`url(${samplePost.data.thumbnail})`);
   });
 
   it('renders category', () => {


### PR DESCRIPTION
##### Description
Right now image is just attached to the top-left corner of container and
being cropped. To make sure that it's responsive and scales nicely
across different device widths, I've added image's url to the container
utilizing `background-image` and `background-size` css styles.

##### Checklist
- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
`src/containers/BlogPost/BlogPost.tsx`
`test/containers/BlogPost/BlogPost.test.tsx`

##### Screenshots (Optional)
![](https://cl.ly/3a0m3q422P2L/Screen%20Recording%202018-06-25%20at%2010.39%20PM.gif)

##### Testing
Updated tests testing this component.

##### Refers/Fixes
Fixes: #164