### PR TITLE
Use react-static Link component to redirect blog posts

### DIFF
--- a/src/components/Blog/PostPreview.tsx
+++ b/src/components/Blog/PostPreview.tsx
@@ -125,7 +125,7 @@ export default ({ post, featured = false }: Props) => {
   }
 
   return (
-    <a id="blogLink" href={`/blog/post/${post.data.slug}`}>
+    <Link id="blogLink" to={`/blog/post/${post.data.slug}`}>
       <RootWrap>
         <div id="root">
           <div
@@ -172,6 +172,6 @@ export default ({ post, featured = false }: Props) => {
           </div>
         </div>
       </RootWrap>
-    </a>
+    </Link>
   );
 };

--- a/src/components/Blog/VerticalPostPreview.tsx
+++ b/src/components/Blog/VerticalPostPreview.tsx
@@ -87,7 +87,7 @@ class VerticalPostPreview extends React.Component<Props> {
     }
     return (
       <PostItemContainer>
-        <a href={`/blog/post/${post.data.slug}`}>
+        <Link to={`/blog/post/${post.data.slug}`}>
           <Cropper>
             <PostItemImage src={post.data.thumbnail} />
           </Cropper>
@@ -104,7 +104,7 @@ class VerticalPostPreview extends React.Component<Props> {
               escapeHtml={false}
             />
           </Text>
-        </a>
+        </Link>
       </PostItemContainer>
     );
   }

--- a/test/components/Blog/PostPreview.test.tsx
+++ b/test/components/Blog/PostPreview.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Moment from 'react-moment';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import Category from '@components/Blog/Category';
 import PostPreview from '@components/Blog/PostPreview';
 
@@ -19,36 +19,36 @@ describe('<PostPreview />', () => {
   }
 
   it('renders without crashing', () => {
-    const c = mount(<PostPreview post={samplePost} />);
+    const c = shallow(<PostPreview post={samplePost} />);
     expect(c.exists());
   });
 
   it('renders nothing if post prop is undefined', () => {
-    const c = mount(<PostPreview post={undefined} />);
+    const c = shallow(<PostPreview post={undefined} />);
     expect(c.render().text()).toEqual("");
   });
 
   it('renders the category', () => {
-    const c = mount(<PostPreview post={samplePost} />);
+    const c = shallow(<PostPreview post={samplePost} />);
     const categoryC = c.children().find('#blogStatsCategory');
     expect(categoryC.render().text()).toEqual(samplePost.data.category);
   });
 
   it('renders the title', () => {
-    const c = mount(<PostPreview post={samplePost} />);
+    const c = shallow(<PostPreview post={samplePost} />);
     const titleC = c.children().find('#blogTitle');
     expect(titleC.render().text()).toEqual(samplePost.data.title);
   });
 
   it('renders the publish date', () => {
-    const c = mount(<PostPreview post={samplePost} />);
+    const c = shallow(<PostPreview post={samplePost} />);
     const m = mount(<Moment format={'MMMM D, YYYY'}>{samplePost.data.published_at}</Moment>);
     const publishDateC = c.children().find('#blogStatsTime');
     expect(publishDateC.render().text()).toEqual(m.render().text());
   });
 
   it('renders the thumbnail', () => {
-    const c = mount(<PostPreview post={samplePost} />);
+    const c = shallow(<PostPreview post={samplePost} />);
     const thumbnailC = c.children().find('#blogImage');
     expect(thumbnailC.prop('style').backgroundImage).toEqual(`url(${samplePost.data.thumbnail})`);
   });

--- a/test/components/Blog/VerticalPostPreview.test.tsx
+++ b/test/components/Blog/VerticalPostPreview.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import Moment from 'react-moment'
-import { mount } from 'enzyme'
+import { mount, shallow } from 'enzyme'
 import VerticalPostPreview from '@components/Blog/VerticalPostPreview'
 import { cropContent } from '@helpers/cropContent'
+import { MemoryRouter as Router } from 'react-router-dom' // 4.0.0
 
 describe('<VerticalPostPreview />', () => {
   const samplePost = {
@@ -20,46 +21,46 @@ describe('<VerticalPostPreview />', () => {
   }
 
   it('renders without crashing', () => {
-    const c = mount(<VerticalPostPreview post={samplePost} />)
+    const c = shallow(<VerticalPostPreview post={samplePost} />)
     expect(c.exists())
   })
 
   it('renders nothing if post prop is undefined', () => {
-    const c = mount(<VerticalPostPreview post={undefined} />)
+    const c = mount(<Router><VerticalPostPreview post={undefined} /></Router>)
     expect(c.render().text()).toEqual('')
   })
 
   it('renders the publish date', () => {
-    const c = mount(<VerticalPostPreview post={samplePost} />)
+    const c = shallow(<VerticalPostPreview post={samplePost} />)
     const m = mount(<Moment format={'MMMM Do, YYYY'}>{samplePost.data.published_at}</Moment>)
     const publishDateC = c.children().find(Moment)
     expect(publishDateC.render().text()).toEqual(m.render().text())
   })
 
   it('renders the thumbnail', () => {
-    const c = mount(<VerticalPostPreview post={samplePost} />)
-    const thumbnailC = c.children().find('img')
+    const c = mount(<Router><VerticalPostPreview post={samplePost} /></Router>)
+    const thumbnailC = c.childAt(0).children().find('img')
     expect(thumbnailC.prop('src')).toEqual(samplePost.data.thumbnail)
   })
 
   it('wrapps component with the link to the post', () => {
-    const c = mount(<VerticalPostPreview post={samplePost} />)
-    const linkC = c.children().find('a')
+    const c = mount(<Router><VerticalPostPreview post={samplePost} /></Router>)
+    const linkC = c.childAt(0).children().find('a')
     expect(linkC.prop('href')).toEqual(`/blog/post/${samplePost.data.slug}`)
   })
 
   it('renders the category', () => {
-    const c = mount(<VerticalPostPreview post={samplePost} />)
+    const c = mount(<Router><VerticalPostPreview post={samplePost} /></Router>)
     expect(c.render().text()).toContain(samplePost.data.category.toUpperCase())
   })
 
   it('renders the post title', () => {
-    const c = mount(<VerticalPostPreview post={samplePost} />)
+    const c = mount(<Router><VerticalPostPreview post={samplePost} /></Router>)
     expect(c.render().text()).toContain(samplePost.data.title)
   })
 
   it('renders content preview and does not crop content, if it is shorter than crop length is provided', () => {
-    const c = mount(<VerticalPostPreview post={samplePost} />)
+    const c = mount(<Router><VerticalPostPreview post={samplePost} /></Router>)
     expect(c.render().text()).toContain(cropContent(samplePost.content))
   })
 

--- a/test/containers/Blog/Blog.test.tsx
+++ b/test/containers/Blog/Blog.test.tsx
@@ -41,7 +41,7 @@ describe('<Blog />', () => {
   }
 
   beforeEach(() => {
-    component = mount(
+    component = shallow(
       <Blog posts={posts} categories={categories} />
     );
   });


### PR DESCRIPTION
##### Description
The page should not reload and should take advantage of react-static `Link` component

##### Checklist
- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
Blog

##### Testing
Local test

##### Refers/Fixes
Fixes: #165 