### PR TITLE
[WIP] Add "Add to calendar" button

### DIFF
--- a/src/components/About/Opensource.tsx
+++ b/src/components/About/Opensource.tsx
@@ -175,8 +175,9 @@ class Opensource extends React.Component {
                 <ButtonWrapper type="primary">Learn more</ButtonWrapper>
               </Link>
               <Link
+                // tslint does not like the long string
                 // tslint:disable-next-line
-                to="https://calendar.google.com/event?action=TEMPLATE&tmeid=NDllOXB2b2JpbmJjNG9ob2IxbjYybjhhbGtfMjAxODA3MDVUMTQwMDAwWiBrZW4udS5kaWdnaXR0QG0&tmsrc=ken.u.diggitt%40gmail.com&scp=ALL"
+                to="https://calendar.google.com/event?action=TEMPLATE&tmeid=NnVmdnU1NHAyYjdoODk1MGY1YzU2YzVrM25fMjAxODA3MDVUMTQwMDAwWiBtYXJrZXRwcm90b2NvbC5pb190dGE5NmhzdXAxbWViOWVkdHJwMnZuaGZlb0Bn&tmsrc=marketprotocol.io_tta96hsup1meb9edtrp2vnhfeo%40group.calendar.google.com&scp=ALL"
                 target="_blank"
                 style={{ color: 'inherit', textDecoration: 'none' }}
               >

--- a/src/components/About/Opensource.tsx
+++ b/src/components/About/Opensource.tsx
@@ -174,6 +174,14 @@ class Opensource extends React.Component {
               >
                 <ButtonWrapper type="primary">Learn more</ButtonWrapper>
               </Link>
+              <Link
+                // tslint:disable-next-line
+                to="https://calendar.google.com/event?action=TEMPLATE&tmeid=NDllOXB2b2JpbmJjNG9ob2IxbjYybjhhbGtfMjAxODA3MDVUMTQwMDAwWiBrZW4udS5kaWdnaXR0QG0&tmsrc=ken.u.diggitt%40gmail.com&scp=ALL"
+                target="_blank"
+                style={{ color: 'inherit', textDecoration: 'none' }}
+              >
+                <ButtonWrapper type="primary">Add To Calendar</ButtonWrapper>
+              </Link>
             </TextWrapper>
           </Col>
         </Row>

--- a/test/components/About/Opensource.test.tsx
+++ b/test/components/About/Opensource.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import {Col, Row} from 'antd';
+import { Link } from 'react-static';
 import protocol from '@images/about/protocol.svg';
 
 import Opensource, {IllustrationContainer1 } from '@components/About/Opensource';
@@ -36,5 +37,11 @@ describe('<Opensource />', () => {
             .to
             .have
             .length(1);
+    });
+
+    it('renders an Add to Calendar button', () => {
+        const component = shallow(<Opensource/>);
+        const button = component.find(Link);
+        expect(button.at(3).render().text()).to.equal('Add To Calendar');
     });
 });


### PR DESCRIPTION
##### Description
This PR aims to add the Add to Calendar button in the Engineering Weekly section of the about page

##### Checklist
- [ ] Linter status: 100% pass
- [ ] Changes don't break existing behavior
- [ ] Tests coverage hasn't decreased

##### Affected core subsystem(s)
UI, UX

##### Screenshots (Optional) 
![image](https://user-images.githubusercontent.com/1138619/42343226-61b5b7ec-8066-11e8-82ac-ffeff8095d01.png)

![image](https://user-images.githubusercontent.com/1138619/42343508-4637ff60-8067-11e8-8d58-a29c0dab647d.png)

##### Refers/Fixes
Fixes: #181

# Note

I used a dummy link from my own personal calendar. We will need a link from the MARKET Protocol calendar. So don't merge this yet.
