### PR TITLE
Center titles on team

### DIFF
--- a/src/Styles.tsx
+++ b/src/Styles.tsx
@@ -29,6 +29,7 @@ const MarketHeader = styled.h2`
   font-size: 36px;
   font-weight: 500;
   line-height: 1.1;
+  text-align: center;
 
   @media (max-width: ${size.laptop}) {
     font-size: 26px;

--- a/src/components/About/Derivatives.tsx
+++ b/src/components/About/Derivatives.tsx
@@ -9,6 +9,7 @@ import { device, size } from '@src/breakpoints';
 
 export const HeaderText = MarketHeader.extend`
   padding-bottom: 40px;
+  text-align: center;
 
   @media ${device.mobileS} and (max-width: ${size.mobileL}) {
     padding: 60px 20px 20px 20px;

--- a/src/components/About/Timeline.tsx
+++ b/src/components/About/Timeline.tsx
@@ -7,6 +7,7 @@ import timeline from '@images/about/timeline.svg';
 
 export const HeaderText = MarketHeader.extend`
   padding-bottom: 40px;
+  text-align: center;
 
   @media ${device.mobileS} and (max-width: ${size.mobileL}) {
     padding: 60px 20px 20px 20px;

--- a/src/containers/Team/index.tsx
+++ b/src/containers/Team/index.tsx
@@ -85,7 +85,7 @@ export class TeamComponent extends React.Component<{}, State> {
         <Hero />
         {/* 'the team' title and info */}
         <TeamDivWithResponsiveWidth style={{ padding: '40px 0px 20px 0px' }}>
-          <MarketHeader>Core Team</MarketHeader>
+          <MarketHeader style={{ textAlign: 'center' }}>Core Team</MarketHeader>
         </TeamDivWithResponsiveWidth>
 
         {/* team members */}
@@ -108,7 +108,9 @@ export class TeamComponent extends React.Component<{}, State> {
           }}
         >
           <TeamDivWithResponsiveWidth>
-            <MarketHeader>{'Advisors'}</MarketHeader>
+            <MarketHeader style={{ textAlign: 'center' }}>
+              {'Advisors'}
+            </MarketHeader>
           </TeamDivWithResponsiveWidth>
 
           {/* advisors */}


### PR DESCRIPTION
Titles on Team page seemed a bit off amongst the other elements.

##### Checklist
- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
UI

##### Screenshots (Optional) 
![screencapture-localhost-3000-team-2018-07-23-17_38_05](https://user-images.githubusercontent.com/1138619/43104358-2eedbd2c-8e9f-11e8-99c9-560edf006fb7.png)


##### Refers/Fixes
Fixes: #130 