### PR TITLE
Fix undefined history on blog page

### DIFF
--- a/src/components/Blog/PostPreview.tsx
+++ b/src/components/Blog/PostPreview.tsx
@@ -158,7 +158,7 @@ class PostPreview extends React.Component<PostPreviewProps> {
   }
 
   render() {
-    const { post, featured } = this.props;
+    const { post, featured, history } = this.props;
 
     if (!post) {
       return null;


### PR DESCRIPTION
##### Description
When clicking on a post preview `history` was undefined. 

##### Checklist
- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
UI, UX

##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->

##### Refers/Fixes
Fixes: #210 