### PR TITLE
Nav Bar Float Above Partner Image w/ Transparency

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -249,7 +249,9 @@ class Navbar extends React.Component {
         mode={breakpoint === 'desktop' ? 'horizontal' : 'inline'}
         style={{
           float: breakpoint === 'desktop' ? 'right' : 'none',
-          lineHeight: '64px'
+          lineHeight: '64px',
+          position: 'relative',
+          'z-index': '2'
         }}
         onClick={this.handleClick}
         selectedKeys={[this.state.current]}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -249,9 +249,7 @@ class Navbar extends React.Component {
         mode={breakpoint === 'desktop' ? 'horizontal' : 'inline'}
         style={{
           float: breakpoint === 'desktop' ? 'right' : 'none',
-          lineHeight: '64px',
-          position: 'relative',
-          'z-index': '2'
+          lineHeight: '64px'
         }}
         onClick={this.handleClick}
         selectedKeys={[this.state.current]}


### PR DESCRIPTION
##### Description
Top navigation bar floats on top of graphic with a black, translucent background.

##### Checklist
- [x] Linter status: 100% pass

##### Affected core subsystem(s)
UI

##### Screenshots (Optional) 
<img width="1199" alt="screen shot 2018-08-06 at 5 50 26 pm" src="https://user-images.githubusercontent.com/7378617/43742849-63de88f6-99a1-11e8-9ae4-e6889631df0e.png">


##### Testing
Purely aesthetic change. All tests passed.

##### Refers/Fixes
Fixes: https://github.com/MARKETProtocol/website/issues/214
