### PR TITLE
Increased the explainer video thumbnail size and removed the help text

### DIFF
--- a/src/components/ExplainerCta.tsx
+++ b/src/components/ExplainerCta.tsx
@@ -26,8 +26,8 @@ const Wrapper = styled.section`
 
 const IconStyled = styled(Icon)`
   position: absolute;
-  color: #00e2c1;
-  font-size: 25px;
+  color: rgba(240, 240, 240, 0.7);
+  font-size: 45px;
   top: calc(50% - 10px);
   left: calc(50% - 20px);
 `;
@@ -37,6 +37,14 @@ const ExplainerVideoContainer = styled.div`
 
   :hover {
     opacity: 0.8;
+  }
+
+  img {
+    width: 550px;
+
+    @media ${device.mobileS} and (max-width: ${size.tablet}) {
+      width: 100%;
+    }
   }
 `;
 
@@ -84,15 +92,11 @@ class ExplainerCta extends React.Component<
     return (
       <Wrapper>
         <Row type="flex" justify="center" align="middle">
-          <Col xs={24} md={6} xl={3}>
+          <Col xs={24} style={{ textAlign: 'center' }}>
             <ExplainerVideoContainer
               onClick={() => this.setState({ explainerPopUpVisible: true })}
             >
-              <img
-                alt="MARKET Protocol "
-                src={explainerThumbnail}
-                style={{ width: '100%', paddingRight: '25px' }}
-              />
+              <img alt="MARKET Protocol " src={explainerThumbnail} />
               <IconStyled type="play-circle" />
             </ExplainerVideoContainer>
             <Modal
@@ -122,15 +126,15 @@ class ExplainerCta extends React.Component<
               />
             </Modal>
           </Col>
-          <Col xs={24} md={10} xl={6}>
-            <TextWrapper>
-              <h2>What is MARKET Protocol?</h2>
-              <p>
-                Check out our quick video to learn more about MARKET Protocol
-                and its uses.
-              </p>
-            </TextWrapper>
-          </Col>
+          {/*<Col xs={24}>*/}
+          {/*<TextWrapper>*/}
+          {/*<h2>What is MARKET Protocol?</h2>*/}
+          {/*<p>*/}
+          {/*Check out our quick video to learn more about MARKET Protocol*/}
+          {/*and its uses.*/}
+          {/*</p>*/}
+          {/*</TextWrapper>*/}
+          {/*</Col>*/}
         </Row>
       </Wrapper>
     );


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/MARKETProtocol/meta/blob/master/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->
As per Seth's request on increasing the explainer video, I've increased the same and removed the help text which might not be necessary if the thumnail is bigger. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like Docs, UI, UX, Tests etc). -->
UI 

##### Screenshots (Optional) 
<!-- Please attach screenshots of all purposeful UI changes (before and after screens are recommended). -->
<img width="1067" alt="screen shot 2018-09-14 at 12 33 12 pm" src="https://user-images.githubusercontent.com/4952395/45535275-8c2a2480-b81b-11e8-83ba-7ee5a5f01a93.png">


##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->
Tested on different resolutions

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->
- Fixes #243
