### PR TITLE
Fixed issue with the explainer video thumbnail on mobile resolutions

### DIFF
--- a/src/components/ExplainerCta.tsx
+++ b/src/components/ExplainerCta.tsx
@@ -28,7 +28,7 @@ const IconStyled = styled(Icon)`
   position: absolute;
   color: rgba(240, 240, 240, 0.7);
   font-size: 45px;
-  top: calc(50% - 10px);
+  top: calc(50% - 20px);
   left: calc(50% - 20px);
 `;
 
@@ -41,16 +41,12 @@ const ExplainerVideoContainer = styled.div`
 
   img {
     width: 550px;
+  }
 
-    @media ${device.mobileS} and (max-width: ${size.tablet}) {
+  @media ${device.mobileS} and (max-width: ${size.tablet}) {
+    img {
       width: 100%;
     }
-  }
-`;
-
-const TextWrapper = styled.div`
-  @media ${device.mobileS} and (max-width: ${size.tablet}) {
-    margin-top: 25px;
   }
 `;
 
@@ -126,15 +122,6 @@ class ExplainerCta extends React.Component<
               />
             </Modal>
           </Col>
-          {/*<Col xs={24}>*/}
-          {/*<TextWrapper>*/}
-          {/*<h2>What is MARKET Protocol?</h2>*/}
-          {/*<p>*/}
-          {/*Check out our quick video to learn more about MARKET Protocol*/}
-          {/*and its uses.*/}
-          {/*</p>*/}
-          {/*</TextWrapper>*/}
-          {/*</Col>*/}
         </Row>
       </Wrapper>
     );


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/MARKETProtocol/meta/blob/master/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->
Fixing the explainer video being cut off in mobile resolutions

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like Docs, UI, UX, Tests etc). -->
UI

##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->
The issue happens only after creating a build. Verified the fix after building the website. 

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->
Fixes: #253 